### PR TITLE
Add shared develop-feature skill + CLAUDE.md (team AI workflow)

### DIFF
--- a/.claude/skills/develop-feature/README.md
+++ b/.claude/skills/develop-feature/README.md
@@ -1,0 +1,91 @@
+# How to use the `develop-feature` skill
+
+A team guide for building features with Claude Code in this repo, consistently
+and without breaking the architecture. (This README is for humans; `SKILL.md`
+is the instruction set Claude follows.)
+
+## TL;DR
+Open Claude Code in the repo and either type the slash command or just describe
+the feature:
+```
+/develop-feature add a movie Search screen
+```
+or
+```
+Build a "Favorites" screen from this screenshot  [attach image]
+```
+Claude runs a review-gated workflow and **pauses for your confirmation** at each
+GATE. You stay in control.
+
+## What it does (and why)
+Turns a feature request into reviewed, tested, architecture-conformant code:
+discovery → spec → plan → function-only skeleton → layer-by-layer
+implementation → real routing → unit tests. It reuses existing
+models/components/repositories and enforces the project's hard invariants
+(see `references/architecture.md`).
+
+## What to give it (any one of)
+1. **Free-form ("vibe") description** — a sentence or paragraph of what you want.
+2. **Screenshot / image** — attach it; Claude reads the UI and infers widgets.
+3. **A written spec** — use `references/feature-spec-template.md`. You can fill
+   it yourself, or let Claude generate it from (1)/(2) for you to confirm.
+
+The more you provide (endpoints, models, acceptance criteria), the less Claude
+has to assume. Unknowns become explicit questions at the planning gate.
+
+## What happens — the GATES you'll review
+| Phase | You review / decide |
+|-------|---------------------|
+| 1. Intake & spec | The generated spec (`docs/specs/<feature>.md`) — correct it before any code. |
+| 3. Plan & task list | The ordered tasks + key decisions (new module? usecase? design-system extraction?). |
+| 4. Skeleton (fake data) | The screen running via a temporary **preview route**, so you validate the data/error flow early. |
+| 7. Tests & done | Final result against the Definition of Done, then commit. |
+
+Between gates Claude implements layer by layer (model → api → data → view model
+→ UI), regenerating code and running `analyze`/`test` as it goes.
+
+## Worked example
+```
+You:   /develop-feature  add a Search screen: a text field, results list of
+       movies, tap → detail. Uses GET /search/movie?query=.
+Claude: (Phase 1) writes docs/specs/search.md and asks you to confirm.
+You:   confirm (or tweak).
+Claude: (Phase 2-3) maps reuse (Movie model, MovieRepository, list widgets) and
+        shows a task list. You approve.
+Claude: (Phase 4) scaffolds feature_search with an AsyncNotifier returning fake
+        results + a preview route; you run it and review loading/empty/error.
+You:   looks good.
+Claude: (Phase 5-7) wires the real API + repository, polishes UI, adds the route
+        from Home, writes tests, runs the full gate, and commits.
+```
+
+## Fast iteration: the preview route
+During Phase 4 the skill adds a temporary direct route to the new screen, gated
+by a dart-define, so you can run it in isolation:
+```
+flutter run --flavor dev --dart-define=FLAVOR=dev --dart-define=PREVIEW=search
+```
+It is removed when real navigation is wired (Phase 6).
+
+## Extending the skill (for the team)
+- Keep **`SKILL.md`** (the process) stable.
+- Evolve the **`references/`** files as the codebase evolves — each file states
+  what it owns at the top:
+  - `architecture.md` — conventions & invariants (update when a convention changes)
+  - `feature-spec-template.md` — the spec format
+  - `code-templates.md` — per-layer code/test templates
+  - `checklists.md` — decisions, guardrails, Definition of Done, orchestration
+- When you introduce a new pattern, update `architecture.md` **and**
+  `code-templates.md` in the same PR so the skill stays the single source of truth.
+- Changes are shared with everyone via git (the skill lives in `.claude/`).
+
+## When it scales up (Orchestration + Harness)
+For a single feature the linear flow is enough. For large/parallel work (many
+screens, whole-repo discovery), ask Claude to "use a workflow" — see
+`references/checklists.md` §When to orchestrate for the triggers and the
+fan-out/pipeline shape. Review gates still apply.
+
+## Requirements
+Claude Code with this repo open. The skill is auto-discovered from
+`.claude/skills/`. `CLAUDE.md` (repo root) loads the key invariants every
+session, so even quick edits stay consistent.

--- a/.claude/skills/develop-feature/SKILL.md
+++ b/.claude/skills/develop-feature/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: develop-feature
+description: >-
+  Develop a new feature/screen in this Flutter modular codebase, end to end and
+  architecture-safe. Use when the user wants to add a feature, build a screen,
+  turn a spec/screenshot/idea into working code, or scaffold a new module.
+  Walks discovery → spec → plan → function-only skeleton → layer-by-layer
+  implementation → real routing → unit tests, reusing existing code and never
+  breaking the modular architecture.
+---
+
+# Develop a feature (architecture-safe, review-gated)
+
+This skill turns a feature request (free-form "vibe" description, a screenshot,
+or a written spec) into reviewed, tested, architecture-conformant code in this
+Flutter modular monorepo.
+
+**Read these references before acting** (they are the source of truth and the
+team maintains them):
+- `references/architecture.md` — module layout, layers, the mandatory patterns
+  (Riverpod AsyncNotifier, `AsyncValue`, `ref.listen` exception dispatch,
+  freezed, Retrofit, GoRouter, pub workspace) and the hard invariants.
+- `references/feature-spec-template.md` — the spec format to capture/confirm.
+- `references/code-templates.md` — per-layer copy-paste templates that already
+  match the conventions.
+- `references/checklists.md` — Definition of Done, guardrails, and when to
+  escalate to a multi-agent Workflow.
+
+## Operating principles
+
+- **Review-gated.** Stop for user confirmation at the marked GATES. Do not run
+  the whole pipeline unattended.
+- **Reuse first.** Always prefer existing models/components/repositories over
+  new ones. Discovery output must list what to reuse before proposing new code.
+- **Vertical slice, fake-first.** Get a runnable skeleton (real data/error flow,
+  fake data) in front of the user early — before wiring real APIs.
+- **Never break architecture, never leave junk.** Every guardrail in
+  `references/checklists.md` is mandatory. If a step would violate one, stop and
+  surface it.
+- **Verify continuously.** After each phase run the relevant subset of
+  `make generate_sources_all` / `flutter analyze` / `flutter test`.
+
+## Workflow
+
+### Phase 1 — Intake & spec  ⟶ GATE
+1. Identify the input form: free-form text, screenshot/image, or an existing
+   spec. If a screenshot, describe the UI you see and the inferred widgets.
+2. Produce a filled feature spec using `references/feature-spec-template.md`
+   (UI, API, data, navigation, states/errors, acceptance criteria). Save it to
+   `docs/specs/<feature>.md`.
+3. **GATE:** show the spec; ask the user to confirm/correct before any code.
+
+### Phase 2 — Discovery (map reuse vs gaps)
+4. Explore the codebase to decide what already exists vs what is missing. For a
+   feature that touches several layers, fan out parallel read-only `Explore`
+   agents (one each for: core_model, core_network/API, core_data/repositories,
+   core_designsystem components, core_ui base + exception flow, an analogous
+   existing feature, routing). Otherwise do it inline.
+5. Produce a **Reuse Map**: existing models/DTOs, API endpoints, repository
+   methods, design-system widgets, and base classes to reuse — and the **Gaps**
+   that must be built.
+
+### Phase 3 — Plan & task list  ⟶ GATE
+6. From spec + reuse map, write an ordered task list grouped by layer
+   (model → api → data → (usecase?) → viewmodel → ui → routing → tests).
+7. Make the explicit decisions in `references/checklists.md` §Decisions:
+   new core module vs feature-local? domain usecase needed? design-system
+   extraction? Justify each in one line.
+8. **GATE:** present the plan/task list; get approval. Track it with the task
+   tools.
+
+### Phase 4 — Function-only skeleton (fake data)  ⟶ GATE
+9. Scaffold the feature module per `references/code-templates.md`: freezed UI
+   state, an `AsyncNotifier` view model whose `build()` returns **fake** data,
+   and a page that renders loading/data and dispatches errors via
+   `ref.listenException` (see architecture.md). Repository calls are stubbed.
+10. Add a **preview route** for fast iteration: a temporary direct entry to the
+    new screen (see `references/checklists.md` §Preview route) so it runs from
+    `main` without touching real navigation yet.
+11. Build/run to the preview; confirm the **data & error flow** renders.
+12. **GATE:** user reviews the skeleton + data/error flow.
+
+### Phase 5 — Implement layer by layer
+13. Replace stubs with real code in dependency order (model → api → repository
+    → viewmodel → ui polish), using the templates. After each layer:
+    regenerate code, `flutter analyze`, run the preview.
+14. As you go, extract to `core_designsystem` any reusable widget, and to a
+    domain `UseCase` any non-trivial business logic — **only if** the
+    checklist criteria are met (avoid premature extraction).
+
+### Phase 6 — Real routing
+15. Once the screen is confirmed, remove the preview bypass and wire real
+    navigation from the related features/routes into the root Route Tree
+    (`lib/src/route/main_router.dart`, `goRouterProvider`).
+
+### Phase 7 — Tests (functional coverage)  ⟶ GATE
+16. Write unit tests covering the functional spec: view model success/error/edge
+    states (via `ProviderContainer` + mocked repository), repository ↔ exception
+    mapping, and any controller/usecase logic. Target the coverage bar in
+    `references/checklists.md`.
+17. Run `make analyze_all` and `make test_all`; build the app.
+18. **GATE:** final review against the Definition of Done; then commit on a
+    feature branch with a clear message.
+
+## Escalating to Orchestration + Harness
+Default to the linear flow above. Escalate to a deterministic multi-agent
+**Workflow** only when the feature is large or parallelizable — see
+`references/checklists.md` §When to orchestrate for the exact triggers and the
+recommended fan-out/pipeline shape. Workflows require explicit user opt-in.
+
+## Extending this skill (for the team)
+Keep `SKILL.md` (the process) stable; evolve the **references** as the codebase
+evolves. When a new convention is introduced, update `architecture.md` and
+`code-templates.md` in the same PR so the skill stays the single source of
+truth. Each reference file states what it owns at the top.

--- a/.claude/skills/develop-feature/references/architecture.md
+++ b/.claude/skills/develop-feature/references/architecture.md
@@ -1,0 +1,116 @@
+# Architecture conventions (source of truth)
+
+> This file owns: module layout, layer responsibilities, dependency rules, the
+> mandatory state/exception/asset patterns, and the hard invariants. Keep it in
+> sync with the code in the same PR that changes a convention.
+
+See also the long-form docs: `docs/ArchitectureLearningJourney.md`,
+`docs/ExceptionFlowLearningJourney.md`, `docs/ModularizationLearningJourney.md`,
+and the root `README.md` (module-creation guide).
+
+## Module layout & dependency rules
+
+Packages live under `core/` (shared libraries) and `feature/` (user journeys),
+plus the root `app` package (`lib/`). Each is a Flutter package named
+`core_<name>` / `feature_<name>`, exposing ONE barrel `lib/<name>.dart`
+(e.g. `core_network` → `lib/networks.dart`, `feature_home` → `lib/homes.dart`).
+
+Dependency direction (never violate):
+```
+app (lib/)  ──►  feature_*  ──►  core_ui · core_designsystem · core_data
+                                        └─► core_network · core_model ─► core_common
+```
+- A `feature` module MUST NOT depend on another `feature` module.
+- `core` modules may depend on other `core` modules, never on `feature`/`app`.
+- Cross-feature navigation/composition happens only in the `app` package (it is
+  the only package that depends on every feature → it owns the Route Tree).
+
+### Layer responsibilities
+- `core_common` — `BaseException`/`ExceptionState`, `Environment`, `logger`,
+  small shared types (`Tag`, `Redirect`, `Dialogs`, `GlobalAction`).
+- `core_model` — freezed data models (`with _$X, BaseModel`).
+- `core_network` — Dio + Retrofit API clients, interceptors, `TokenStorage`,
+  `NetworkAppError` + `NetworkExceptionMapper`.
+- `core_data` — repository interfaces + impls, `ExceptionMapper`, DI providers.
+- `core_domain` — optional `UseCase`s (kept as an empty convention; add only
+  when business logic warrants — see checklists §Decisions).
+- `core_designsystem` — theme, colors, reusable Material 3 components, FlutterGen
+  assets.
+- `core_ui` — UI base helpers: `LoadingIndicator`, `ErrorPage`, `CustomDialog`,
+  `showExceptionBehavior` / `WidgetRef.listenException`, `ContextExtension`.
+- `feature_*` — a screen + its view model(s) + feature-local widgets.
+
+## State management — MANDATORY pattern
+
+Riverpod 2.6.x with code generation. **View models are `@riverpod`
+AsyncNotifiers**; the UI consumes `AsyncValue`.
+
+- `build()` returns the data (or throws); loading/data/error are represented by
+  `AsyncValue`, NOT a custom state class.
+- Fetch concurrently (`Future.wait`, or start futures then await) — never
+  sequential awaits for independent calls.
+- Long-lived screens: `@Riverpod(keepAlive: true)`. Parameterised screens:
+  `build(SomeId id)` → family provider; default (auto-dispose) for detail-style.
+- The generated provider replaces hand-written providers. Do NOT write
+  `StateNotifierProvider` / manual `*Provider` for view models.
+
+**Do NOT reintroduce the retired legacy pattern:** `StateNotifier`,
+`BaseViewModel`, `UiState`/`BaseUiState`, `ExceptionStatelessWidget`,
+`SingleObserver` were removed. Use AsyncNotifier + AsyncValue + `ref.listen`.
+
+## Exception / error flow — MANDATORY
+
+Errors converge to `BaseException` (sealed `ExceptionState`, subdivided by user
+behaviour: `Toast`, `SnackBar`, `Alert`, `Dialog`, `Inline`, `Redirect`,
+`OnPage`). Pipeline:
+```
+Dio/Retrofit error → NetworkAppError.from(e) → ExceptionMapper.mapperTo(...)
+  → throws an ExceptionState → AsyncNotifier surfaces it as AsyncError
+  → page: ref.listenException(context, provider) dispatches the side effect
+          (toast/snackbar/alert/dialog); OnPageException → inline ErrorPage.
+```
+- Repository methods convert errors at the `.catchError` boundary via
+  `ExceptionMapper`. Never let a raw `DioException` reach the view model.
+- Side effects (toast/dialog/redirect) go through `ref.listen` — NEVER inside
+  `build()`.
+- `NetworkExceptionMapper.mapperTo` logs every API error via `logger` (debug
+  only).
+
+## Navigation
+
+One Route Tree in the app package: `goRouterProvider` (`lib/src/route/
+main_router.dart`), a `Provider<GoRouter>`. State-driven redirects use
+`redirect` + `refreshListenable` fed by a Riverpod provider (see
+`feature_tutorial` / `onboardingControllerProvider` for the reference pattern).
+`Application` is a `ConsumerWidget` that watches `goRouterProvider`.
+
+## Models & serialization
+
+`freezed` (pinned `>=3.1.0 <3.2.0`) + `json_serializable`. Data classes:
+`@freezed abstract class X with _$X, BaseModel { const X._(); const factory
+X(...) = _X; factory X.fromJson(...) }`. Unions: `sealed class`. Generic freezed
+classes MUST mix in `_$X<T>` (with the type arg).
+
+## Build, codegen, assets
+
+- Dart **pub workspace**: every package has `resolution: workspace` and is
+  listed under `workspace:` in the root `pubspec.yaml`; one shared
+  `pubspec.lock`. `flutter pub get` at root (or `make pub_get_all`) resolves all.
+- Codegen: `make generate_sources_all` (freezed/json/retrofit/riverpod).
+- Assets: FlutterGen via the standalone CLI (`make gen_assets`) — do NOT add
+  `flutter_gen_runner` to build_runner. Assets live in their owning module with
+  `package_parameter_enabled` so they bundle once and are referenced via
+  `packages/<module>/...`.
+- Secrets/config via `--dart-define` (`API_ENDPOINT`, `API_KEY`); never hardcode.
+
+## Hard invariants (violating any = stop and surface)
+
+1. Dependency direction above; no feature→feature deps; routing only in `app`.
+2. AsyncNotifier + AsyncValue + `ref.listen`; no StateNotifier/UiState/
+   SingleObserver/ExceptionStatelessWidget.
+3. Errors as `ExceptionState` via the mapper; no raw exceptions in UI.
+4. `freezed` stays pinned `<3.2.0` (retrofit_generator needs `source_gen <3`).
+5. New module ⇒ `resolution: workspace` + add to root `workspace:` + barrel.
+6. No `flutter_gen_runner`; assets via `make gen_assets`.
+7. One public barrel per module; keep `src/` private.
+8. Generated files (`*.g.dart`/`*.freezed.dart`/`*.gen.dart`) are committed.

--- a/.claude/skills/develop-feature/references/checklists.md
+++ b/.claude/skills/develop-feature/references/checklists.md
@@ -1,0 +1,69 @@
+# Checklists, decisions & escalation
+
+> This file owns: the per-phase decisions, the architecture guardrails, the
+> Definition of Done, and when to escalate to a multi-agent Workflow.
+
+## §Decisions (make explicit at the Plan gate, justify each in one line)
+
+- **New core module vs feature-local?** New `core_*` module only if the code is
+  (or will be) used by ≥2 features. Otherwise keep it inside the feature.
+- **Domain UseCase?** Add a `core_domain` UseCase only when there is real
+  business logic (orchestration across repositories, non-trivial rules). For a
+  straight read/CRUD, the view model calls the repository directly.
+- **Design-system extraction?** Move a widget to `core_designsystem` only when
+  it is reused across features or is clearly a generic component. Do not extract
+  one-off feature widgets (avoid premature abstraction / junk).
+- **New model vs reuse?** Prefer reusing/extending `core_model` types. New model
+  only for genuinely new shapes.
+- **Persistence?** none → shared_preferences (flags/prefs) → secure_storage
+  (tokens/secrets) → DB. Don't pull a DB for a single flag.
+
+## §Preview route (Phase 4)
+- Add a temporary `GoRoute` to the new screen + an `initialLocation` override
+  gated by `--dart-define=PREVIEW=<feature>` (see code-templates §7).
+- Purpose: review UI + data/error flow in isolation, fast, before real nav.
+- MUST be removed in Phase 6 when real routing is wired. Grep for `PREVIEW`
+  before committing the final feature.
+
+## §Guardrails (every one is mandatory — see architecture.md invariants)
+- [ ] Dependency direction respected; no feature→feature import; routing only in `app`.
+- [ ] View model is `@riverpod` AsyncNotifier; UI uses `AsyncValue`; side effects via `ref.listen`.
+- [ ] No `StateNotifier`/`UiState`/`SingleObserver`/`ExceptionStatelessWidget`.
+- [ ] Errors flow as `ExceptionState` via `ExceptionMapper`; no raw `DioException` in UI.
+- [ ] freezed stays `>=3.1.0 <3.2.0`; no `flutter_gen_runner`; assets via `make gen_assets`.
+- [ ] New module has `resolution: workspace`, is in root `workspace:`, has one barrel + `.gitignore`.
+- [ ] Reused existing code where the Reuse Map said so (no duplicate models/widgets/endpoints).
+- [ ] Secrets via `--dart-define`; nothing hardcoded.
+- [ ] Preview bypass removed.
+
+## §Definition of Done
+- [ ] Spec confirmed and saved under `docs/specs/`.
+- [ ] All acceptance criteria from the spec are met and covered by a test.
+- [ ] `make generate_sources_all` clean; `make analyze_all` → 0 issues (all modules).
+- [ ] `make test_all` green; functional coverage = every acceptance criterion +
+      view model success/error/edge + repository↔exception mapping.
+- [ ] App builds (`flutter build apk --flavor dev --dart-define=FLAVOR=dev`);
+      ideally smoke-run the screen.
+- [ ] No guardrail violated; no dead code/preview left; barrels updated.
+- [ ] Committed on a feature branch with a descriptive message.
+
+## §When to orchestrate (escalate to a multi-agent Workflow)
+Default = run this skill linearly with one agent. Escalate ONLY when the user
+opts in ("use a workflow" / ultracode) AND one of:
+- the feature spans **many modules/screens** (e.g. several screens, or new
+  model+api+data+ui+routing all sizeable);
+- **discovery must sweep the whole repo** (large unknown codebase area);
+- there are **independent parallel slices** (multiple screens/endpoints that can
+  be built and verified concurrently).
+
+Recommended shape:
+- **Discovery (parallel/barrier):** one `Explore` agent per area (model, api,
+  data, designsystem, ui/exception, analogous feature, routing) → merge into one
+  Reuse Map.
+- **Implementation (pipeline):** one item per screen/endpoint; stages
+  `scaffold → implement → verify(analyze+test)`; isolate file-mutating agents
+  with `isolation: worktree` if they run concurrently.
+- **Verify (adversarial):** a final agent re-checks every guardrail + runs
+  `analyze_all`/`test_all` before reporting.
+Keep human review GATES between Workflow phases — do not let orchestration skip
+the spec/plan/skeleton confirmations.

--- a/.claude/skills/develop-feature/references/code-templates.md
+++ b/.claude/skills/develop-feature/references/code-templates.md
@@ -1,0 +1,204 @@
+# Code templates (per layer)
+
+> This file owns the canonical code shape for each layer. Replace `Foo`/`foo`.
+> These match the live patterns in `feature_home`, `feature_detail`,
+> `feature_tutorial`, `core_data`, `core_network`. Keep in sync with the code.
+
+## 0. New module pubspec (`feature/foo/pubspec.yaml`)
+```yaml
+name: feature_foo
+description: "Foo feature"
+version: 1.0.0+1
+publish_to: none
+resolution: workspace            # REQUIRED: joins the pub workspace
+
+environment:
+  sdk: '>=3.6.0 <4.0.0'
+
+dependencies:
+  flutter: { sdk: flutter }
+  hooks_riverpod: ^2.6.1
+  riverpod_annotation: ^2.6.1
+  go_router: ^14.1.4
+  core_model: { path: ../../core/model }
+  core_common: { path: ../../core/common }
+  core_ui: { path: ../../core/ui }
+  core_data: { path: ../../core/data }
+  core_designsystem: { path: ../../core/designsystem }
+
+dev_dependencies:
+  flutter_test: { sdk: flutter }
+  flutter_lints: ^5.0.0
+  build_runner: ^2.4.8
+  riverpod_generator: ^2.6.1
+  freezed: '>=3.1.0 <3.2.0'        # only if the module declares freezed classes
+  freezed_annotation: ^3.0.0       # (move to dependencies if used)
+  json_serializable: ^6.7.1
+  mockito: ^5.4.4                  # if writing repository mocks
+```
+Then: add `feature/foo` to root `workspace:` AND as a `feature_foo: { path:
+feature/foo }` dependency where consumed; create barrel `lib/foos.dart`; copy a
+sibling module's `.gitignore`.
+
+## 1. Model (`core_model/lib/src/foo.dart`)
+```dart
+import 'package:core_model/src/base_model.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'foo.freezed.dart';
+part 'foo.g.dart';
+
+@freezed
+abstract class Foo with _$Foo, BaseModel {
+  const Foo._();
+  const factory Foo({ int? id, @JsonKey(name: 'display_name') String? name }) = _Foo;
+  factory Foo.fromJson(Map<String, dynamic> json) => _$FooFromJson(json);
+}
+```
+Export from `core_model/lib/models.dart`. Generic class → `with _$Foo<T>, ...`.
+
+## 2. API (`core_network/lib/src/remote/api/foo_api.dart`)
+```dart
+import 'package:core_model/models.dart';
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';   // full barrel (ParseErrorLogger)
+part 'foo_api.g.dart';
+
+@RestApi()
+abstract class FooApi {
+  factory FooApi(Dio dio) = _FooApi;
+  @GET('/foo/{id}')
+  Future<Foo> getFoo(@Path('id') int id, @Query('api_key') String key);
+}
+```
+Provider in `core_network/lib/src/di/network_provider.dart`:
+`final fooApiProvider = Provider<FooApi>((ref) => FooApi(ref.watch(dioBuilderProvider)));`
+
+## 3. Repository (`core_data/lib/src/repository/...`)
+```dart
+abstract class FooRepository { Future<Foo> getFoo(int id); }
+
+class FooRepositoryImpl implements FooRepository {
+  final FooApi _api; final String _apiKey; final ExceptionMapper _mapper;
+  FooRepositoryImpl(this._api, {String? apiKey, ExceptionMapper? exceptionMapper})
+      : _mapper = exceptionMapper ?? ExceptionMapper(),
+        _apiKey = apiKey ?? Environment.shared().apiKey;
+
+  @override
+  Future<Foo> getFoo(int id) => _api.getFoo(id, _apiKey)
+      .catchError((e) async => throw await _mapper.mapperTo(NetworkAppError.from(e)));
+}
+final fooRepositoryProvider = Provider<FooRepository>(
+    (ref) => FooRepositoryImpl(ref.watch(fooApiProvider)));
+```
+
+## 4. UI state (`feature_foo/lib/src/ui/foo_ui_state.dart`)
+```dart
+@freezed
+abstract class FooData with _$FooData {
+  const factory FooData({ required Foo foo, @Default(false) bool expanded }) = _FooData;
+}
+```
+
+## 5. View model — AsyncNotifier (`.../foo_view_model.dart`)
+SKELETON (Phase 4, fake data):
+```dart
+@riverpod
+class FooViewModel extends _$FooViewModel {
+  @override
+  Future<FooData> build(int id) async {
+    // TODO(real): final repo = ref.watch(fooRepositoryProvider); ...
+    await Future<void>.delayed(const Duration(milliseconds: 300)); // simulate
+    return const FooData(foo: Foo(id: 0, name: 'Sample'));
+  }
+}
+```
+REAL (Phase 5):
+```dart
+@riverpod
+class FooViewModel extends _$FooViewModel {
+  @override
+  Future<FooData> build(int id) async {
+    final repo = ref.watch(fooRepositoryProvider);
+    final foo = await repo.getFoo(id);
+    return FooData(foo: foo);
+  }
+  void toggle() {
+    final cur = state.valueOrNull;
+    if (cur != null) state = AsyncData(cur.copyWith(expanded: !cur.expanded));
+  }
+}
+```
+`part 'foo_view_model.g.dart';` + `import 'package:riverpod_annotation/...';`.
+Use `@Riverpod(keepAlive: true)` for long-lived screens.
+
+## 6. Page — ConsumerWidget (`.../foo_page.dart`)
+```dart
+class FooPage extends ConsumerWidget {
+  const FooPage({super.key, required this.id});
+  final int id;
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listenException(context, fooViewModelProvider(id));     // toast/dialog
+    return Scaffold(
+      body: Stack(children: [
+        Consumer(builder: (context, ref, _) {
+          final showError = ref.watch(fooViewModelProvider(id)
+              .select((s) => s.error is OnPageException && !s.hasValue));
+          if (showError) {
+            final e = ref.read(fooViewModelProvider(id)).error as OnPageException;
+            return ErrorPage(message: e.messageId?.tr() ?? e.message ?? '',
+                retry: () => ref.invalidate(fooViewModelProvider(id)));
+          }
+          return _content(context, id);
+        }),
+        Consumer(builder: (context, ref, _) {
+          final loading = ref.watch(fooViewModelProvider(id).select((s) => s.isLoading));
+          return loading ? const LoadingIndicator() : const SizedBox();
+        }),
+      ]),
+    );
+  }
+  Widget _content(BuildContext context, int id) => Consumer(builder: (context, ref, _) {
+    final name = ref.watch(fooViewModelProvider(id).select((s) => s.valueOrNull?.foo.name));
+    return Center(child: Text(name ?? ''));
+  });
+}
+```
+Barrel `lib/foos.dart`: `export 'src/ui/foo_page.dart'; export 'src/ui/foo_view_model.dart';`
+
+## 7. Preview route (Phase 4 — temporary, REMOVE in Phase 6)
+Run straight to the new screen without touching real navigation:
+```dart
+// lib/main.dart — guarded by a dart-define so it never ships
+const _preview = String.fromEnvironment('PREVIEW');   // e.g. PREVIEW=foo
+// in app router initialLocation: _preview == 'foo' ? '/foo-preview' : '/'
+// + a GoRoute('/foo-preview', builder: (_, __) => const FooPage(id: 1))
+```
+Launch: `flutter run --flavor dev --dart-define=FLAVOR=dev --dart-define=PREVIEW=foo`.
+
+## 8. Unit test (`feature_foo/test/src/ui/foo_view_model_test.dart`)
+```dart
+@GenerateMocks([FooRepository])
+void main() {
+  late MockFooRepository repo; late ProviderContainer container;
+  setUp(() => repo = MockFooRepository());
+  ProviderContainer make() {
+    final c = ProviderContainer(overrides: [fooRepositoryProvider.overrideWithValue(repo)]);
+    addTearDown(c.dispose); return c;
+  }
+  test('build returns data on success', () async {
+    when(repo.getFoo(1)).thenAnswer((_) async => const Foo(id: 1, name: 'x'));
+    container = make();
+    final data = await container.read(fooViewModelProvider(1).future);
+    expect(data.foo.name, 'x');
+  });
+  test('surfaces AsyncError when repository throws', () async {
+    final ex = Exception('boom');
+    when(repo.getFoo(1)).thenThrow(ex);
+    container = make();
+    await expectLater(container.read(fooViewModelProvider(1).future), throwsA(ex));
+    expect(container.read(fooViewModelProvider(1)), isA<AsyncError<FooData>>());
+  });
+}
+```
+For SharedPreferences-backed controllers, use `SharedPreferences.setMockInitialValues({...})`.

--- a/.claude/skills/develop-feature/references/feature-spec-template.md
+++ b/.claude/skills/develop-feature/references/feature-spec-template.md
@@ -1,0 +1,64 @@
+# Feature spec template
+
+> This file owns the spec format. Copy the block below to
+> `docs/specs/<feature>.md`, fill it in (from text / screenshot / API docs),
+> and confirm with the user before coding. Leave a field `TBD` if unknown — TBD
+> fields become open questions at the planning gate.
+
+```markdown
+# Feature: <name>
+
+## 1. Summary
+- **Goal / user value:** <one or two sentences>
+- **Module:** feature_<name>  (new? yes/no)
+- **Entry points:** <where the user reaches this screen from>
+- **Input source:** free-form | screenshot | spec  (attach/describe)
+
+## 2. UI
+- **Screens:** <list; one main screen unless stated>
+- **Layout / sections:** <top→bottom; e.g. app bar, carousel, list, CTA>
+- **Components:** <reuse from core_designsystem? new? which>
+- **States to render:** loading | empty | data | error(OnPage)
+- **Interactions:** <taps, navigation, toggles, pull-to-refresh, pagination>
+- **Design ref:** <screenshot/Figma link or "n/a">
+
+## 3. Data & API
+- **Models needed:** <new models / reuse core_model.X>
+- **Endpoints:**
+  | Method | Path | Query/Body | Response model | Notes |
+  |--------|------|------------|----------------|-------|
+  | GET    | /... |            | <Model>        |       |
+- **Repository methods:** <signatures; reuse MovieRepository-style>
+- **Persistence:** none | shared_preferences | secure_storage | db (which)
+- **Business logic / UseCase:** <rules; or "none — direct repository">
+
+## 4. Errors & behaviour
+For each failure, map to an ExceptionState behaviour:
+| Case | Behaviour | Message |
+|------|-----------|---------|
+| network/timeout | Toast | ... |
+| validation | Inline | per-field |
+| server (fatal) | OnPage + retry | ... |
+| auth expired | Redirect | login |
+
+## 5. Navigation
+- **Route path(s):** <e.g. /foo, /foo/:id>
+- **Args:** <passed via extra / path params>
+- **Redirect/guards:** <auth/onboarding conditions, or none>
+
+## 6. Acceptance criteria (functional — drives the tests)
+- [ ] <observable behaviour 1>
+- [ ] <state X renders when ...>
+- [ ] <error case Y shows behaviour Z>
+- [ ] <navigation A → B works>
+
+## 7. Out of scope / open questions
+- <explicitly excluded items>
+- <TBD items needing a decision>
+```
+
+## Reading a screenshot into this spec
+When the input is an image: enumerate the visible regions top→bottom, name the
+likely existing design-system component for each (app bar, list tile, card,
+rating, carousel), infer the data each region needs, and record anything
+ambiguous as an open question rather than guessing.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ app.*.map.json
 /android/app/release
 
 **/coverage
+# Claude Code: personal local settings
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md — project guide for AI assistants
+
+Modular Flutter monorepo (architecture inspired by Now in Android). This file is
+auto-loaded every session so all contributors get consistent, high-quality
+output. Keep it short; detailed conventions live in the skill references.
+
+## Building a feature
+Use the **`develop-feature`** skill (`.claude/skills/develop-feature/`). It owns
+the end-to-end, review-gated workflow (discovery → spec → plan → skeleton →
+implement → routing → tests) and references the canonical conventions. Invoke it
+for any "add a feature / build a screen / turn this spec or screenshot into code"
+request.
+
+## Hard invariants (do not violate — full list in the skill's architecture.md)
+1. **Dependency direction:** `app → feature_* → core_ui/designsystem/data →
+   core_network/model → core_common`. No feature→feature deps. Routing lives only
+   in the `app` package (`lib/src/route/main_router.dart`, `goRouterProvider`).
+2. **State:** view models are `@riverpod` AsyncNotifiers; UI consumes
+   `AsyncValue`; side effects (toast/dialog/redirect) via `ref.listen`
+   (`ref.listenException`). The legacy `StateNotifier`/`UiState`/`SingleObserver`/
+   `ExceptionStatelessWidget` were removed — do not reintroduce them.
+3. **Errors:** converge to `BaseException`/`ExceptionState` via `ExceptionMapper`;
+   no raw `DioException` in the UI.
+4. **Codegen:** `freezed` pinned `>=3.1.0 <3.2.0` (retrofit_generator needs
+   `source_gen <3`). `make generate_sources_all` for freezed/json/retrofit/
+   riverpod. Generated files are committed.
+5. **Workspace:** Dart pub workspace — every package has `resolution: workspace`
+   and is listed in the root `workspace:`; one shared `pubspec.lock`. New module ⇒
+   register it + add one barrel `lib/<name>.dart` + a `.gitignore`.
+6. **Assets:** FlutterGen via the standalone CLI (`make gen_assets`); never add
+   `flutter_gen_runner`. Assets bundle once from their owning module
+   (`package_parameter_enabled`).
+7. **Config/secrets:** via `--dart-define` (`FLAVOR`, `API_ENDPOINT`, `API_KEY`).
+
+## Commands
+- Resolve deps: `make pub_get_all`  ·  Codegen: `make generate_sources_all`  ·
+  Assets: `make gen_assets`
+- Quality gate: `make analyze_all` then `make test_all`
+- Run: `flutter run --flavor dev --dart-define=FLAVOR=dev`
+
+## Environment
+Flutter 3.44.4 / Dart 3.12.2 · iOS 13+ · Android minSdk 21 / target 35 (Gradle
+8.9 / AGP 8.7.3 / Kotlin 2.1 / Java 17).


### PR DESCRIPTION
## What's this PR do?

Adds a **project-level, git-shared AI workflow** so the whole team produces
consistent, architecture-safe features with Claude Code. Independent of the
code-modernization PR (#11) — this is tooling only.

### Contents
- **`.claude/skills/develop-feature/SKILL.md`** — a review-gated workflow:
  intake/spec → discovery (reuse map) → plan/task-list → function-only skeleton
  (fake data + a temporary preview route) → layer-by-layer implementation →
  real routing → functional unit tests. Stops at human GATES.
- **`references/architecture.md`** — canonical conventions + hard invariants
  (dependency direction, Riverpod AsyncNotifier + `AsyncValue` + `ref.listen`,
  exception flow, freezed pin, pub workspace, FlutterGen-without-build_runner).
- **`references/feature-spec-template.md`** — spec format accepting free-form
  text, a screenshot, or a written spec.
- **`references/code-templates.md`** — copy-paste templates per layer + tests.
- **`references/checklists.md`** — decisions, guardrails, Definition of Done,
  and when to escalate to a multi-agent Workflow (Orchestration + Harness).
- **`CLAUDE.md`** — auto-loaded invariants + commands, so even ad-hoc work
  stays consistent. `settings.local.json` is gitignored (personal).

### How the team uses it
- Invoke `/develop-feature` (or just ask to add a feature / build a screen from
  a spec or screenshot) — the skill drives the architecture-safe process.
- Extend by editing the `references/*` files (each states what it owns); keep
  `SKILL.md` stable. Update `architecture.md` + `code-templates.md` in the same
  PR whenever a convention changes.

### Design rationale
Process is separated from knowledge so the team can extend the references
without destabilizing the workflow, keeping output unified and high quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)